### PR TITLE
Start the environment using Mix.

### DIFF
--- a/lib/local_cluster.ex
+++ b/lib/local_cluster.ex
@@ -60,17 +60,8 @@ defmodule LocalCluster do
     rpc.(:code, :add_paths, [ :code.get_path() ])
 
     rpc.(Application, :ensure_all_started, [ :mix ])
-    rpc.(Application, :ensure_all_started, [ :logger ])
-
-    rpc.(Logger, :configure, [ level: Logger.level() ])
     rpc.(Mix, :env, [ Mix.env() ])
-
-    for { app_name, _, _ } <- Application.loaded_applications() do
-      for { key, val } <- Application.get_all_env(app_name) do
-        rpc.(Application, :put_env, [ app_name, key, val ])
-      end
-      rpc.(Application, :ensure_all_started, [ app_name ])
-    end
+    rpc.(Mix.CLI, :main, [])
 
     nodes
   end


### PR DESCRIPTION
When starting the nodes the current implementation does not take in account applications deps, which results in application started out of order and configurations wrongly merged. Using Mix allow to start in the correct order with the very same environment that the developer expects.