### PR TITLE
Allow `Node.spawn/2` to work out of the box.

### DIFF
--- a/test/local_cluster_test.exs
+++ b/test/local_cluster_test.exs
@@ -1,5 +1,6 @@
 defmodule LocalClusterTest do
   use ExUnit.Case
+  require LocalCluster
   doctest LocalCluster
 
   test "creates and stops child nodes" do
@@ -22,5 +23,19 @@ defmodule LocalClusterTest do
     assert Node.ping(node1) == :pang
     assert Node.ping(node2) == :pang
     assert Node.ping(node3) == :pang
+  end
+
+  test "can send anonymous function to child node" do
+    [node] = LocalCluster.start_nodes(:spawn_child, 1)
+
+    assert Node.ping(node) == :pong
+
+    test_pid = self()
+    spawn(fn -> send(test_pid, :hello_local) end)
+
+    Node.spawn(node, fn -> send(test_pid, :hello_cluster) end)
+
+    assert_receive :hello_local
+    assert_receive :hello_cluster
   end
 end


### PR DESCRIPTION
Hi,

I was playing with your library this morning, but I can't seem to get it to work. I've added the smallest test case that I could think of that didn't do what I was expecting.

Could you take a look? Am I doing something wrong?

One possibility is that I'm testing this in a library that is not an "application". (this library itself is also not an application).

Thanks
Derek