### PR TITLE
Fix param for setting remote log level

### DIFF
--- a/lib/local_cluster.ex
+++ b/lib/local_cluster.ex
@@ -62,7 +62,7 @@ defmodule LocalCluster do
     rpc.(Application, :ensure_all_started, [ :mix ])
     rpc.(Application, :ensure_all_started, [ :logger ])
 
-    rpc.(Logger, :configure, [ level: Logger.level() ])
+    rpc.(Logger, :configure, [ [level: Logger.level()] ])
     rpc.(Mix, :env, [ Mix.env() ])
 
     for { app_name, _, _ } <- Application.loaded_applications() do


### PR DESCRIPTION
The remote log level wasn't being set correctly due to the subtleties of how Elixir handles keyword lists.

`[a: :b]` gets interpreted as `[{:a, :b}]`, but the args list needs `[[{:a, :b}]]`, since the keyword list is just one of multiple possible arguments. This patch gets the log level set correctly.