### PR TITLE
Ensure all configuration merged before starts loaded applications in child nodes

### DIFF
--- a/lib/local_cluster.ex
+++ b/lib/local_cluster.ex
@@ -74,7 +74,9 @@ defmodule LocalCluster do
       for {key, val} <- Application.get_all_env(app_name) do
         rpc.(Application, :put_env, [app_name, key, val])
       end
+    end
 
+    for {app_name, _, _} <- Application.loaded_applications() do
       rpc.(Application, :ensure_all_started, [app_name])
     end
 

--- a/lib/local_cluster.ex
+++ b/lib/local_cluster.ex
@@ -17,19 +17,21 @@ defmodule LocalCluster do
     start_boot_server = fn ->
       # voodoo flag to generate a "started" atom flag
       :global_flags.once("local_cluster:started", fn ->
-        { :ok, _ } = :erl_boot_server.start([
-          { 127, 0, 0, 1 }
-        ])
+        {:ok, _} =
+          :erl_boot_server.start([
+            {127, 0, 0, 1}
+          ])
       end)
+
       :ok
     end
 
     # only ever handle the :erl_boot_server on the initial startup
-    case :net_kernel.start([ :"manager@127.0.0.1" ]) do
+    case :net_kernel.start([:"manager@127.0.0.1"]) do
       # handle nodes that have already been started elsewhere
-      { :error, { :already_started, _ } } -> start_boot_server.()
+      {:error, {:already_started, _}} -> start_boot_server.()
       # handle the node being started
-      { :ok, _ } -> start_boot_server.()
+      {:ok, _} -> start_boot_server.()
       # pass anything else
       anything -> anything
     end
@@ -43,39 +45,43 @@ defmodule LocalCluster do
   nodes are linked to the current process, and so will terminate when the
   parent process does for automatic cleanup.
   """
-  @spec start_nodes(binary, integer, Keyword.t) :: [ atom ]
+  @spec start_nodes(binary, integer, Keyword.t()) :: [atom]
   def start_nodes(prefix, amount, options \\ [])
-  when (is_binary(prefix) or is_atom(prefix)) and is_integer(amount) do
-    nodes = Enum.map(1..amount, fn idx ->
-      { :ok, name } = :slave.start_link(
-        '127.0.0.1',
-        :"#{prefix}#{idx}",
-        '-loader inet -hosts 127.0.0.1 -setcookie "#{:erlang.get_cookie()}"'
-      )
-      name
-    end)
+      when (is_binary(prefix) or is_atom(prefix)) and is_integer(amount) do
+    nodes =
+      Enum.map(1..amount, fn idx ->
+        {:ok, name} =
+          :slave.start_link(
+            '127.0.0.1',
+            :"#{prefix}#{idx}",
+            '-loader inet -hosts 127.0.0.1 -setcookie "#{:erlang.get_cookie()}"'
+          )
 
-    rpc = &({ _, [] } = :rpc.multicall(nodes, &1, &2, &3))
+        name
+      end)
 
-    rpc.(:code, :add_paths, [ :code.get_path() ])
+    rpc = &({_, []} = :rpc.multicall(nodes, &1, &2, &3))
 
-    rpc.(Application, :ensure_all_started, [ :mix ])
-    rpc.(Application, :ensure_all_started, [ :logger ])
+    rpc.(:code, :add_paths, [:code.get_path()])
 
-    rpc.(Logger, :configure, [ level: Logger.level() ])
-    rpc.(Mix, :env, [ Mix.env() ])
+    rpc.(Application, :ensure_all_started, [:mix])
+    rpc.(Application, :ensure_all_started, [:logger])
 
-    for { app_name, _, _ } <- Application.loaded_applications() do
-      for { key, val } <- Application.get_all_env(app_name) do
-        rpc.(Application, :put_env, [ app_name, key, val ])
+    rpc.(Logger, :configure, level: Logger.level())
+    rpc.(Mix, :env, [Mix.env()])
+
+    for {app_name, _, _} <- Application.loaded_applications() do
+      for {key, val} <- Application.get_all_env(app_name) do
+        rpc.(Application, :put_env, [app_name, key, val])
       end
-      rpc.(Application, :ensure_all_started, [ app_name ])
+
+      rpc.(Application, :ensure_all_started, [app_name])
     end
 
     for file <- Keyword.get(options, :files, []) do
-      { :ok, source } = File.read(file)
+      {:ok, source} = File.read(file)
 
-      for { module, binary } <- Code.compile_string(source, file) do
+      for {module, binary} <- Code.compile_string(source, file) do
         rpc.(:code, :load_binary, [
           module,
           :unicode.characters_to_list(file),
@@ -90,14 +96,14 @@ defmodule LocalCluster do
   @doc """
   Stops a set of child nodes.
   """
-  @spec stop_nodes([ atom ]) :: :ok
+  @spec stop_nodes([atom]) :: :ok
   def stop_nodes(nodes) when is_list(nodes),
     do: Enum.each(nodes, &:slave.stop/1)
 
   @doc """
   Stops the current distributed node and turns it back into a local node.
   """
-  @spec stop :: :ok | { :error, atom }
+  @spec stop :: :ok | {:error, atom}
   def stop,
     do: :net_kernel.stop()
 end

--- a/mix.exs
+++ b/mix.exs
@@ -16,12 +16,12 @@ defmodule LocalCluster.MixProject do
           "mix.exs",
           "LICENSE"
         ],
-        licenses: [ "MIT" ],
+        licenses: ["MIT"],
         links: %{
           "Docs" => @url_docs,
           "GitHub" => @url_github
         },
-        maintainers: [ "Isaac Whitfield" ]
+        maintainers: ["Isaac Whitfield"]
       },
       version: @version,
       elixir: "~> 1.2",
@@ -29,7 +29,7 @@ defmodule LocalCluster.MixProject do
       docs: [
         main: "LocalCluster",
         source_ref: "v#{@version}",
-        source_url: @url_github,
+        source_url: @url_github
       ],
       aliases: [
         test: "test --no-start"
@@ -49,9 +49,9 @@ defmodule LocalCluster.MixProject do
   defp deps do
     [
       # Production dependencies
-      { :global_flags, "~> 1.0" },
+      {:global_flags, "~> 1.0"},
       # Local dependencies, not shipped with the app
-      { :ex_doc, "~> 0.16", optional: true, only: [ :docs ] }
+      {:ex_doc, "~> 0.16", optional: true, only: [:docs]}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,8 @@
+%{
+  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.21.3", "857ec876b35a587c5d9148a2512e952e24c24345552259464b98bfbb883c7b42", [:mix], [{:earmark, "~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "global_flags": {:hex, :global_flags, "1.0.0", "ee6b864979a1fb38d1fbc67838565644baf632212bce864adca21042df036433", [:rebar3], [], "hexpm"},
+  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm"},
+}

--- a/test/local_cluster_test.exs
+++ b/test/local_cluster_test.exs
@@ -25,11 +25,12 @@ defmodule LocalClusterTest do
   end
 
   test "spawns tasks directly on child nodes" do
-    nodes = LocalCluster.start_nodes(:spawn, 3, [
-      files: [
-        __ENV__.file
-      ]
-    ])
+    nodes =
+      LocalCluster.start_nodes(:spawn, 3,
+        files: [
+          __ENV__.file
+        ]
+      )
 
     [node1, node2, node3] = nodes
 


### PR DESCRIPTION
_Please review df9be34 mainly, other commits are unrelated to main issue._

The current implementation copies application config (`Application.put_env/4`) and starts loaded applications (`Application.ensure_all_started/2`) simultaneously. But it can start an application before copying its configuration if other application starts it.

So in this PR, I modified code to starts applications after all configuration merged.