### PR TITLE
Added option to specify applications to start on cluster nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,23 @@ After calling `start_nodes/2`, you will receive a list of node names you can the
 to communicate with via RPC or however you'd like. Although they're automatically cleaned
 up when the calling process dies, you can manually stop nodes as well to test disconnection.
 
+`start_nodes/3` accepts list of options as an additional parameter.
+Two options are currently supported: `:app_names` and `:files`, as described below.
+
+Use option `:app_names` with an ordered list of application names for scenarios
+where the order of applications starting is critical, or where only a subset of apps is desired. 
+If the option is not present, all currently running applications will be started on each node, 
+in the same order as reported by `Application.loaded_applications/0`.
+Note that each application is started via `Application.ensure_all_started/2`, i.e. with all dependencies.
+
+```elixir
+    nodes = LocalCluster.start_nodes(:cluster, 16, [
+      app_names: [
+        :start_this_application, :and_then_this_one
+      ]
+    ])
+```
+
 If you need to load any additional files onto the remote nodes, you can make use of the
 `:files` option at startup time by providing an absolute file path to compile on the
 cluster. This is necessary if you wish to spawn tasks onto the cluster from inside your

--- a/lib/local_cluster.ex
+++ b/lib/local_cluster.ex
@@ -42,6 +42,18 @@ defmodule LocalCluster do
   and return the names of the nodes to the user for further use. All child
   nodes are linked to the current process, and so will terminate when the
   parent process does for automatic cleanup.
+
+  Option `:app_names` specifies ordered list of applications to be started
+  on child nodes. This is useful if only a subset of applications is needed.
+  Application dependencies are started automatically.
+  Note that only applications already loaded in current node will be started,
+  other app names are silently ignored.
+  Without this option, all currently loaded applications will be included.
+
+  Option `:files` can be used to load additional files onto the remote nodes.
+  Value is a list of absolute file paths to compile on the cluster.
+  This is necessary if you wish to spawn tasks onto the cluster from inside
+  the test code, as the test code is not loaded into the cluster automatically.
   """
   @spec start_nodes(binary, integer, Keyword.t) :: [ atom ]
   def start_nodes(prefix, amount, options \\ [])
@@ -65,10 +77,16 @@ defmodule LocalCluster do
     rpc.(Logger, :configure, [ level: Logger.level() ])
     rpc.(Mix, :env, [ Mix.env() ])
 
-    for { app_name, _, _ } <- Application.loaded_applications() do
+    # copy all application environment values
+    loaded_apps = for { app_name, _, _ } <- Application.loaded_applications() do
       for { key, val } <- Application.get_all_env(app_name) do
         rpc.(Application, :put_env, [ app_name, key, val ])
       end
+      app_name
+    end
+
+    # start apps in specified order
+    for app_name <- Keyword.get(options, :app_names, loaded_apps), app_name in loaded_apps do
       rpc.(Application, :ensure_all_started, [ app_name ])
     end
 

--- a/test/local_cluster_test.exs
+++ b/test/local_cluster_test.exs
@@ -36,7 +36,7 @@ defmodule LocalClusterTest do
                  |> Enum.map(fn {app_name, _, _} -> app_name end)
     assert :local_cluster in node1_apps
     assert :ex_unit in node1_apps
-    assert :no_real_app not in node1_apps
+    assert (:no_real_app in node1_apps) == false
 
     :ok = LocalCluster.stop_nodes(nodes)
   end

--- a/test/local_cluster_test.exs
+++ b/test/local_cluster_test.exs
@@ -24,6 +24,23 @@ defmodule LocalClusterTest do
     assert Node.ping(node3) == :pang
   end
 
+  test "load selected applications" do
+    nodes = LocalCluster.start_nodes(:child, 2, [
+      app_names: [
+        :local_cluster, :ex_unit, :no_real_app
+      ]
+    ])
+    [node1, _node2] = nodes
+
+    node1_apps = :rpc.call(node1, Application, :loaded_applications, [])
+                 |> Enum.map(fn {app_name, _, _} -> app_name end)
+    assert :local_cluster in node1_apps
+    assert :ex_unit in node1_apps
+    assert :no_real_app not in node1_apps
+
+    :ok = LocalCluster.stop_nodes(nodes)
+  end
+
   test "spawns tasks directly on child nodes" do
     nodes = LocalCluster.start_nodes(:spawn, 3, [
       files: [


### PR DESCRIPTION
* Default behaviour: `start_nodes/3` starts all applications that are loaded on the master node. 
  There are situations where some apps are not desirable on slave nodes, or where their start order is causing problems.
* New option `:app_names` accepts an ordered list of applications to be started.
  Very useful for test scenarios where only a subset of apps should be copied over,
  or where the order of applications starting is critical.
* Note that each application is started via `Application.ensure_all_started/2`, i.e. with all dependencies.