### PR TITLE
Code.compile_string/2 seems to interfere with other ExUnit tests

### DIFF
--- a/lib/local_cluster.ex
+++ b/lib/local_cluster.ex
@@ -72,16 +72,9 @@ defmodule LocalCluster do
       rpc.(Application, :ensure_all_started, [ app_name ])
     end
 
+    # compile and load additional files on each node
     for file <- Keyword.get(options, :files, []) do
-      { :ok, source } = File.read(file)
-
-      for { module, binary } <- Code.compile_string(source, file) do
-        rpc.(:code, :load_binary, [
-          module,
-          :unicode.characters_to_list(file),
-          binary
-        ])
-      end
+      rpc.(Code, :require_file, [file])
     end
 
     nodes


### PR DESCRIPTION
* Using `LocalCluster.start_nodes/3` with option `:files`
  in an umbrella project corrupted the ExUnit test management.
  The test file was re-compiled and re-executed for each subsequent
  umbrella app. A warning was emitted for each re-compile:
  `warning: redefining module XXX (current version defined in memory)`
* This change avoids code changes on the master node by moving the compilation
  to each slave node (assuming the compiler is loaded there).

Note that this PR changes implementation for #8.
Will it work for you? Is there a better solution? Please advise.