### PR TITLE
Allow user to override the Application environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,23 @@ defmodule MyTest do
   end
 end
 ```
+
+If you need to override the application environment inherrited by the remote nodes,
+then you can use the `:env_override` option at startup. This keyword list is merged
+onto the Application environment when specified:
+
+```elixir
+defmodule MyTest do
+  use ExUnit.Case
+
+  test "override app environment" do
+    [remote_node] = LocalCluster.start_nodes(:spawn, 1, [
+      env_override: [
+        my_app: [port: 9999]
+      ]
+    ])
+
+    assert :rpc.block_call(remote_node, Application, :get_env, [:my_app, :port]) = 9999
+  end
+end
+```

--- a/lib/local_cluster.ex
+++ b/lib/local_cluster.ex
@@ -66,7 +66,10 @@ defmodule LocalCluster do
     rpc.(Mix, :env, [ Mix.env() ])
 
     for { app_name, _, _ } <- Application.loaded_applications() do
-      for { key, val } <- Application.get_all_env(app_name) do
+      env_override = get_in(options, [ :env_override, app_name ]) || []
+      app_env = Application.get_all_env(app_name) |> Keyword.merge(env_override)
+
+      for { key, val } <- app_env do
         rpc.(Application, :put_env, [ app_name, key, val ])
       end
       rpc.(Application, :ensure_all_started, [ app_name ])


### PR DESCRIPTION
In order to pass a different environment into the remote node when starting it, the user must change their local Application env, start the node, then change it back.
For simple cases this works fine, but once tests are running in parallel, this can cause chaos.

This PR adds an :env_override option that allows the user to inject different environmental variables into the remote node. This is especially useful when each group of nodes in a test must start up on a different port or with different app options enabled.

Build passed: https://travis-ci.org/github/whitfin/local-cluster/builds/667949124