### PR TITLE
Allow skipping the loading of certain applications on remote nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,23 @@ defmodule MyTest do
   end
 end
 ```
+
+## Skipping Applications on Remote Nodes
+
+If you need to skip running certain applications on remote nodes, you can configure this in your 
+`config/test.exs`:
+
+```elixir
+config :local_cluster, skip_applications: [:propcheck]
+```
+
+You may need to also add `runtime: false` to your `mix.exs` for that dependency and manually load
+it in your `test_helper.exs`:
+
+```elixir
+# mix.exs
+{:propcheck, "~> 1.1", only: [:test, :dev], runtime: false}
+
+# test_helper.exs
+Application.ensure_all_started(:propcheck)
+```

--- a/lib/local_cluster.ex
+++ b/lib/local_cluster.ex
@@ -65,7 +65,8 @@ defmodule LocalCluster do
     rpc.(Logger, :configure, [ level: Logger.level() ])
     rpc.(Mix, :env, [ Mix.env() ])
 
-    for { app_name, _, _ } <- Application.loaded_applications() do
+    for {app_name, _, _} <- Application.loaded_applications(),
+        app_name not in Application.get_env(:local_cluster, :skip_applications) do
       for { key, val } <- Application.get_all_env(app_name) do
         rpc.(Application, :put_env, [ app_name, key, val ])
       end


### PR DESCRIPTION
This fixes an issue (specifically with propcheck) where the other nodes
would fail to boot. Propcheck tries to access it's context dets file at
boot and having multiple instances launch at the same time causes errors
like:

```
06:42:50.228 [info]  Application propcheck exited:
   PropCheck.App.start(:normal, []) returned an error: shutdown: failed
to start child: PropCheck.CounterStrike
    ** (EXIT) an exception was raised:
        ** (MatchError) no match of right hand side value: {:error,{:not_a_dets_file, '_build/propcheck.ctex'}}
            (propcheck 1.2.0) lib/counterstrike.ex:53:PropCheck.CounterStrike.init/1
            (stdlib 3.9.2) gen_server.erl:374: :gen_server.init_it/2
            (stdlib 3.9.2) gen_server.erl:342: :gen_server.init_it/6
            (stdlib 3.9.2) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```

The solution for this is to allow local cluster to skip loading certain
dependencies when booting the other nodes.