### PR TITLE
Correctly set applications environment in spawned nodes and start only started applications

### DIFF
--- a/lib/local_cluster.ex
+++ b/lib/local_cluster.ex
@@ -85,13 +85,14 @@ defmodule LocalCluster do
         |> Keyword.get(app_name, [])
         |> Keyword.merge(base, fn _, v, _ -> v end)
 
+      rpc.(Application, :load, [ app_name ])
       for { key, val } <- environment do
         rpc.(Application, :put_env, [ app_name, key, val ])
       end
 
       app_name
     end
-
+    
     ordered_apps = Keyword.get(options, :applications, loaded_apps)
 
     for app_name <- ordered_apps, app_name in loaded_apps do

--- a/lib/local_cluster.ex
+++ b/lib/local_cluster.ex
@@ -93,7 +93,9 @@ defmodule LocalCluster do
       app_name
     end
     
-    ordered_apps = Keyword.get(options, :applications, loaded_apps)
+    started_applications = Application.started_applications()
+
+    ordered_apps = Keyword.get(options, :applications, started_applications)
 
     for app_name <- ordered_apps, app_name in loaded_apps do
       rpc.(Application, :ensure_all_started, [ app_name ])


### PR DESCRIPTION
This patch fixes two minor issues:

- when setting env, the application must be loaded (and not started) before calling Application.put_env, otherwise if the app is not loaded when env is set, the defaults from the app will overwrite the ones set by local_cluster
- start only already started applications: sometimes there're apps that are loaded and not started, like the ones that have `runtime: false` in mix.exs. Starting them may lead to errors