### PR TITLE
Support arbitrary manager node name

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Application.ensure_all_started(:my_app)
 ExUnit.start()
 ```
 
+> If you need your test runner to use a specific node name, you may set it by passing
+> the `:name` option to `LocalCluster.start/1`.
+
 You will also need to pass the `--no-start` flag to `mix test`. Fortunately this is
 easy enough, as you can add an alias in your `mix.exs` to do this automatically:
 


### PR DESCRIPTION
This PR allows the LocalCluster library to work with any node name instead of the hardcoded `manager@127.0.0.1`. This may be useful if other parts of the test suite require a specific basename or externally reachable hostname. In my case, the requirement was for the test runner node to be reachable from Docker nodes that are needed for integration testing (these nodes run a completely different pre-built Elixir project so LocalCluster is still needed for testing clustering of the current project).

This is not a breaking change in any way since `manager@127.0.0.1` is still the default and the dynamic host lookup (that allows this lib to work properly even if `:net_kernel.start` is invoked before & outside of `LocalCluster.start`) will yield the same value as the previously hardcoded one.

I've provided a test case that requires a custom host in `/etc/hosts` but the test case nicely explains it all and it reverts to the original default setup.