### PR TITLE
Interface to specify the node names exactly

### DIFF
--- a/lib/local_cluster.ex
+++ b/lib/local_cluster.ex
@@ -57,10 +57,19 @@ defmodule LocalCluster do
   @spec start_nodes(binary, integer, Keyword.t) :: [ atom ]
   def start_nodes(prefix, amount, options \\ [])
   when (is_binary(prefix) or is_atom(prefix)) and is_integer(amount) do
-    nodes = Enum.map(1..amount, fn idx ->
+    node_names= for idx <- 1..amount, do: :"#{prefix}#{idx}"
+    start_named_nodes(node_names, options)
+  end
+
+  @doc """
+  Same as `LocalCluster.start_nodes/3` but allows the exact node names to be specified.
+  """
+  @spec start_named_nodes(list, Keyword.t) :: [ atom ]
+  def start_named_nodes(node_names, options \\ []) when is_list(node_names) do
+    nodes = Enum.map(node_names, fn ndname ->
       { :ok, name } = :slave.start_link(
         '127.0.0.1',
-        :"#{prefix}#{idx}",
+        :"#{ndname}",
         '-loader inet -hosts 127.0.0.1 -setcookie "#{:erlang.get_cookie()}"'
       )
       name

--- a/test/local_cluster_test.exs
+++ b/test/local_cluster_test.exs
@@ -102,4 +102,20 @@ defmodule LocalClusterTest do
     assert node2_env == "test2"
     assert node3_env == Application.get_env(:local_cluster, :override)
   end
+
+  test "passing in node names" do
+    nodes = LocalCluster.start_named_nodes([:tnode_one, :tnode_two])
+
+    [node1, node2] = nodes
+    assert node1 == :"tnode_one@127.0.0.1"
+    assert node2 == :"tnode_two@127.0.0.1"
+
+    assert Node.ping(node1) == :pong
+    assert Node.ping(node2) == :pong
+
+    :ok = LocalCluster.stop_nodes([node1])
+
+    assert Node.ping(node1) == :pang
+    assert Node.ping(node2) == :pong
+  end
 end


### PR DESCRIPTION
Sometimes required if the application under test is using predefined node names.

I've had to do this a few times in my tests now. So others may find it useful