### PR TITLE
Replaced :slave with :peer.

### DIFF
--- a/test/local_cluster_test.exs
+++ b/test/local_cluster_test.exs
@@ -5,19 +5,19 @@ defmodule LocalClusterTest do
   test "creates and stops child nodes" do
     nodes = LocalCluster.start_nodes(:child, 3)
 
-    [node1, node2, node3] = nodes
+    [{node1, n1pid}, {node2, n2pid}, {node3, n3pid}] = nodes
 
     assert Node.ping(node1) == :pong
     assert Node.ping(node2) == :pong
     assert Node.ping(node3) == :pong
 
-    :ok = LocalCluster.stop_nodes([node1])
+    :ok = LocalCluster.stop_nodes([n1pid])
 
     assert Node.ping(node1) == :pang
     assert Node.ping(node2) == :pong
     assert Node.ping(node3) == :pong
 
-    :ok = LocalCluster.stop_nodes([node2, node3])
+    :ok = LocalCluster.stop_nodes([n2pid, n3pid])
 
     assert Node.ping(node1) == :pang
     assert Node.ping(node2) == :pang
@@ -33,7 +33,7 @@ defmodule LocalClusterTest do
       ]
     ])
 
-    [node1] = nodes
+    [{node1, _}] = nodes
 
     node1_apps =
       node1
@@ -44,7 +44,9 @@ defmodule LocalClusterTest do
     assert :ex_unit in node1_apps
     assert (:no_real_app in node1_apps) == false
 
-    :ok = LocalCluster.stop_nodes(nodes)
+    peer_pids = Enum.map(nodes, &(elem(&1, 1)))
+
+    :ok = LocalCluster.stop_nodes(peer_pids)
   end
 
   test "spawns tasks directly on child nodes" do
@@ -54,7 +56,7 @@ defmodule LocalClusterTest do
       ]
     ])
 
-    [node1, node2, node3] = nodes
+    [{node1, _}, {node2, _}, {node3, _}] = nodes
 
     assert Node.ping(node1) == :pong
     assert Node.ping(node2) == :pong
@@ -80,19 +82,19 @@ defmodule LocalClusterTest do
   end
 
   test "overriding environment variables on child nodes" do
-    [node1] = LocalCluster.start_nodes(:cluster_var_a, 1, [
+    [{node1, _}] = LocalCluster.start_nodes(:cluster_var_a, 1, [
       environment: [
         local_cluster: [override: "test1"]
       ]
     ])
 
-    [node2] = LocalCluster.start_nodes(:cluster_var_b, 1, [
+    [{node2, _}] = LocalCluster.start_nodes(:cluster_var_b, 1, [
       environment: [
         local_cluster: [override: "test2"]
       ]
     ])
 
-    [node3] = LocalCluster.start_nodes(:cluster_no_env, 1)
+    [{node3, _}] = LocalCluster.start_nodes(:cluster_no_env, 1)
 
     node1_env = :rpc.call(node1, Application, :get_env, [:local_cluster, :override])
     node2_env = :rpc.call(node2, Application, :get_env, [:local_cluster, :override])


### PR DESCRIPTION
The old :slave module is deprecated and will be removed from OTP 27. I replaced the :slave module with the :peer module.
I fixed the tests. This change is not backward compatible because the :peer module starts `{:ok, pid, peer}` where `pid` is used to shutdown the peer nodes and `peer` is used as the node name. Meaning the `start_nodes/3` function should also include the `pid` from now on.