### PR TITLE
Supports :peer module (>= OTP 25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ defmodule MyTest do
   use ExUnit.Case
 
   test "something with a required cluster" do
-    nodes = LocalCluster.start_nodes("my-cluster", 3)
+    peers = LocalCluster.start_nodes("my-cluster", 3)
 
-    [node1, node2, node3] = nodes
+    [node1, node2, node3] = LocalCluster.nodes(peers)
 
     assert Node.ping(node1) == :pong
     assert Node.ping(node2) == :pong
@@ -99,7 +99,7 @@ defmodule MyTest do
 end
 ```
 
-After calling `start_nodes/2`, you will receive a list of node names you can then use
+After calling `start_nodes/2`, you will receive a list of peers you can then use
 to communicate with via RPC or however you'd like. Although they're automatically cleaned
 up when the calling process dies, you can manually stop nodes as well to test disconnection.
 
@@ -129,13 +129,13 @@ defmodule MyTest do
   use ExUnit.Case
 
   test "spawning tasks on a cluster" do
-    nodes = LocalCluster.start_nodes(:spawn, 3, [
+    peers = LocalCluster.start_nodes(:spawn, 3, [
       files: [
         __ENV__.file
       ]
     ])
 
-    [node1, node2, node3] = nodes
+    [node1, node2, node3] = LocalCluster.nodes(peers)
 
     assert Node.ping(node1) == :pong
     assert Node.ping(node2) == :pong

--- a/lib/local_cluster/peer.ex
+++ b/lib/local_cluster/peer.ex
@@ -1,0 +1,67 @@
+defmodule LocalCluster.Peer do
+  @moduledoc """
+  Contains metadata about a peer that has been started with `LocalCluster.start_nodes/2`
+  or `LocalCluster.start_nodes/3`.
+  """
+  import Kernel, except: [node: 1]
+
+  @type t :: %__MODULE__{}
+
+  defstruct [:node, :pid]
+
+  @doc """
+  Given a list of `LocalCluster.Peer` structs, returns the
+  node names.
+
+  The node names can be used for `:rpc` calls.
+  """
+  def nodes(peers) when is_list(peers) do
+    Enum.map(peers, &node/1)
+  end
+
+  @doc """
+  Given a `LocalCluster.Peer`, returns the node name.
+
+  The node name can be used for `:rpc` calls.
+  """
+  def node(%__MODULE__{node: node}) do
+    node
+  end
+
+  def start_link(prefix, idx) do
+    args =
+      ~w[-loader inet -hosts 127.0.0.1 -setcookie #{:erlang.get_cookie()}]
+      |> Enum.map(&String.to_charlist/1)
+
+    {:ok, pid, node} =
+      start_link_int(%{
+        host: ~c"127.0.0.1",
+        name: :"#{prefix}#{idx}",
+        args: args
+      })
+
+    {:ok, %__MODULE__{node: node, pid: pid}}
+  end
+
+  def stop(%__MODULE__{pid: pid, node: node}) do
+    stop_int(pid, node)
+  end
+
+  if Code.ensure_loaded?(:peer) and function_exported?(:peer, :start_link, 1) do
+    def start_link_int(opts), do: :peer.start_link(opts)
+    def stop_int(pid, _node), do: :peer.stop(pid)
+  else
+    # Support for OTP < 25
+    def start_link_int(%{host: host, name: name, args: args}) do
+      case :slave.start_link(host, name, :string.join(args, ~c" ")) do
+        {:ok, node} ->
+          {:ok, nil, node}
+
+        error ->
+          error
+      end
+    end
+
+    def stop_int(_pid, node), do: :slave.stop(node)
+  end
+end


### PR DESCRIPTION
Hello, it appears that the PR for :peer has become stagnant (#28). Will you consider this in its place? Thanks!

API change: `LocalCluster.start_nodes/3` no longer returns node names. See `LocalCluster.nodes/1`.
